### PR TITLE
Fix regex for SSH keys

### DIFF
--- a/src/openstack_workload_generator/entities/helpers.py
+++ b/src/openstack_workload_generator/entities/helpers.py
@@ -175,7 +175,7 @@ class Config:
 
     @staticmethod
     def get_admin_vm_ssh_key() -> str:
-        return Config.get("admin_vm_ssh_key", r"ssh-\S+\s\S+\s\S+", multi_line=True)
+        return Config.get("admin_vm_ssh_key", r"ssh-\S+\s\S+(\s\S+)+", multi_line=True)
 
     @staticmethod
     def get_admin_domain_password() -> str:


### PR DESCRIPTION
Comments on SSH public keys can contain spaces. With this change the the workload generator will no longer choke on such keys.